### PR TITLE
Add data to query string when method is GET or HEAD

### DIFF
--- a/modules/ajax.js
+++ b/modules/ajax.js
@@ -178,6 +178,10 @@ export default function ajax(url, settings) {
         error(new Error(xhr.statusText || 'Network request failed'), 'error', xhr, opts);
     };
 
+    if ((opts.method === 'GET' || opts.method === 'HEAD') && typeof opts.data === 'string') {
+        opts.url += (~opts.url.indexOf('?') ? '&' : '?') + opts.data;
+    }
+
     xhr.open(opts.method, opts.url);
 
     if (opts.dataType && dataTypes[opts.dataType.toLowerCase()]) {

--- a/test/ajax.spec.js
+++ b/test/ajax.spec.js
@@ -24,7 +24,8 @@ describe('tiny.ajax', () => {
             error,
             complete,
             dataType: 'json',
-            method: 'GET'
+            method: 'GET',
+            data: 'a=1&b=2'
         });
     });
 


### PR DESCRIPTION
Since if the request method is GET or HEAD the data is ignored and request body is set to null.