### PR TITLE
Add support to preloaded requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - "8"
   - "6"
   - "4"
-  - "0.12"
 install:
   - npm install
 script: npm test

--- a/modules/ajax.js
+++ b/modules/ajax.js
@@ -19,7 +19,8 @@ export default function ajax(url, settings) {
         credentials: 'omit',
         success: noop,
         error: noop,
-        complete: noop
+        complete: noop,
+        preload: false
     };
 
     opts = extend(defaults, settings || {});
@@ -184,24 +185,28 @@ export default function ajax(url, settings) {
 
     xhr.open(opts.method, opts.url);
 
-    if (opts.dataType && dataTypes[opts.dataType.toLowerCase()]) {
-        opts.headers.Accept = `${dataTypes[opts.dataType.toLowerCase()]}, */*; q=0.01`;
-    }
-
-    // Set the "X-Requested-With" header only if it is not already set
-    if (!opts.crossDomain && !opts.headers['X-Requested-With']) {
-        opts.headers['X-Requested-With'] = 'XMLHttpRequest';
-    }
-
     if (opts.credentials === 'include') {
         xhr.withCredentials = true;
     }
 
-    opts.data = normalizeRequestData(opts.data, opts.headers, opts.crossDomain);
+    // If the ajax will use preload, it must not have headers for match with the request
+    // made by <link rel="preload" as="fetch">.
+    if (!opts.preload) {
+        if (opts.dataType && dataTypes[opts.dataType.toLowerCase()]) {
+            opts.headers.Accept = `${dataTypes[opts.dataType.toLowerCase()]}, */*; q=0.01`;
+        }
 
-    if (!useXDR) {
-        for (let key in opts.headers) {
-            xhr.setRequestHeader(key, opts.headers[key]);
+        // Set the "X-Requested-With" header only if it is not already set
+        if (!opts.crossDomain && !opts.headers['X-Requested-With']) {
+            opts.headers['X-Requested-With'] = 'XMLHttpRequest';
+        }
+
+        opts.data = normalizeRequestData(opts.data, opts.headers, opts.crossDomain);
+
+        if (!useXDR) {
+            for (let key in opts.headers) {
+                xhr.setRequestHeader(key, opts.headers[key]);
+            }
         }
     }
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Returns an `Object`.
 
 ### `tiny.extend([deep,] target, ...sources)`
 
-Copy all of the properties of the sources to the target object and returns the 
+Copy all of the properties of the sources to the target object and returns the
   resulting object. The last source will override properties of the same name in
   previous object.
 
@@ -102,7 +102,7 @@ The most relevant methods:
 **[WIP]**
 
 **See the [external module](https://www.npmjs.com/package/events) and the
-  [docs](https://nodejs.org/api/events.html#events_class_events_eventemitter) 
+  [docs](https://nodejs.org/api/events.html#events_class_events_eventemitter)
   for a complete reference.**
 
 
@@ -223,7 +223,7 @@ Get the parent of an element, optionally filtered by a tag
 
 ### `tiny.next(el)`
 
-Get the next element sibling 
+Get the next element sibling
 
 - `el`: An `HTMLElement`
 
@@ -232,7 +232,7 @@ Get the next element sibling
 
 Get the value of a computed style for the first element in set of
   matched elements or set one or more CSS properties for every matched element.
-  
+
 - `el`: An `HTMLElement` or a valid CSS selector.
 - `key`: A CSS property name. Can be an object of property-value pairs to set.
 - `value`: A value to set for the property.
@@ -260,11 +260,12 @@ Performs an asynchronous HTTP (Ajax) request.
     - `headers`: type `Object` A list of additional headers, for example `{ 'X-Auth': 'auth-token' }`
     - `context`: type `Object` Every callback will be called in context of `settings.context` or `window` if not provided
     - `dataType`: type `String` A mime type, [json,html,text]
-    - `method`: type `String` A valid HTTP method, [GET|POST|PUT|DELETE] 
+    - `method`: type `String` A valid HTTP method, [GET|POST|PUT|DELETE]
     - `credentials`: type `Sting` Use the `"include"` value to send cookies in a CORS request, not supported in IE lte 9. Default is `"omit"`
     - `success`: type `Function` A success callback that receives response data, status and xhr object.
     - `error`: type `Function` An error callback that receives xhr, status and error object.
     - `complete`: A success callback that receives response data, status and xhr object.
+    - `preload`: type `Boolean`.  If set to `true`, it will sent requests without HTTP headers to match with the preloaded resource by the browser. Default: `false`.
 
 Example:
 ```js
@@ -284,7 +285,7 @@ Performs a JSONP request
 - `url`: type `String`. The URL of the requested resource.
 - `settings`: type `Object`. Optional.
     - `prefix`: type `String`. Prefix for the callback functions that handle JSONP responses. Default: `"__jsonp"`
-    - `name`: type `String|Function`. A name of the callback function that handle JSONP response. 
+    - `name`: type `String|Function`. A name of the callback function that handle JSONP response.
         Can be a function that receives the prefix and the request id (increment). Default: `settings.prefix + increment`
     - `param`: type `String`. A name of the query string parameter. Default: `"callback"`
     - `timeout`: type `Number`. How long after the request until a timeout error will occur. Default: `15000`
@@ -305,8 +306,8 @@ tiny.jcors(
         $("#demo").html("jQuery Loaded");
     },
     "http://xxxx/jquery.cookie.js",
-    function() {  
-        $.cookie('not_existing'); 
+    function() {
+        $.cookie('not_existing');
     }
 );
 ```

--- a/test/ajax.spec.js
+++ b/test/ajax.spec.js
@@ -29,6 +29,28 @@ describe('tiny.ajax', () => {
         });
     });
 
+    it('is should make a GET request with preload', (done) => {
+        let completeCallback = function(xhr, status) {
+            expect(typeof xhr).to.equal('object');
+            expect(typeof status).to.equal('string');
+            expect(success).to.have.been.called.once;
+            expect(complete).to.have.been.called.with('success');
+            expect(error).to.not.have.been.called();
+            done();
+        };
+
+        let success = chai.spy();
+        let error = chai.spy();
+        let complete = chai.spy(completeCallback);
+
+        ajax('mock/sites.json', {
+            success,
+            error,
+            complete,
+            preload: true
+        });
+    });
+
     it('is should make a POST request', (done) => {
         let successCallback = function(data, status) {
             expect(success).to.have.been.called.once;


### PR DESCRIPTION
El motivo del PR es ya que al usar `<link rel="preload" as="fetch" />` el request se envía sin headers y al hacer el request vía ajax, si hay header definidos, el browser lo interpreta como un request diferente y no matchea con el preload. Por lo tanto, se disparan dos requests.